### PR TITLE
fixes bug in song_controller_spec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,4 +55,12 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
 end


### PR DESCRIPTION
When running the tests, received error that #set_flash wasn't a method for the controller. 

Found solution here:
https://github.com/thoughtbot/shoulda-matchers/issues/903

and updated the rails_helper to add the appropriate shoulda framework